### PR TITLE
feat: export typescript to avoid inconsistency version between user and mwcc

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
+import * as ts from 'typescript';
 import tsquery from './tsquery/query';
+
+export { tsquery, ts };
 
 export * from './orchestra';
 export { CompilerHost } from './compiler-host';
@@ -9,4 +12,3 @@ export * from './transformation/type';
 export { template } from './template';
 export { Analyzer } from './comprehension/analyze';
 export { getCodeOfNode } from './util';
-export { tsquery };

--- a/test/export.test.ts
+++ b/test/export.test.ts
@@ -1,0 +1,9 @@
+import assert from 'assert';
+import { ts } from '../src';
+import * as typescript from 'typescript';
+
+describe('export', () => {
+  it('should export typescript', async () => {
+    assert.deepStrictEqual(ts, typescript);
+  });
+});


### PR DESCRIPTION
The compiler plugin should use the mwcc export, avoid inconsistency between user version and mwcc version.

Example:

> TypeScript 4.1.3
```ts
console.log(ts.SyntaxKind.SourceFile) // 297
```

> TypeScript 3.9.7
```ts
console.log(ts.SyntaxKind.SourceFile) // 290
```

## Changes

```diff
- import ts from 'typescript' // 4.1.3
+ import { ts } from 'mwcc' // 3.9.3
```